### PR TITLE
Remove redundant colon

### DIFF
--- a/.template/tags.html.erb
+++ b/.template/tags.html.erb
@@ -44,7 +44,7 @@
     <section><% Hash[tags.sort].each do |tag, entries| %>
       <h2><a href='/tags/<%= tag.gsub(' ', '%20') %>.html'><%= tag %></a></h2>
       <ul><% entries.each do |e| %>
-        <li><time datetime=<%= e.created_at %>><%= e.created_at %></time>: <a href=<%= e.url %>><%= e.title %></a><span class=tags>[<%= e.tags.map{|tag| "<a href='/tags/#{tag.gsub(' ', '%20')}.html'>#{tag}</a>" }.join(",") %>]</span><% end %>
+        <li><time datetime=<%= e.created_at %>><%= e.created_at %></time><a href=<%= e.url %>><%= e.title %></a><span class=tags>[<%= e.tags.map{|tag| "<a href='/tags/#{tag.gsub(' ', '%20')}.html'>#{tag}</a>" }.join(",") %>]</span><% end %>
       </ul><% end %>
     </section>
   </main>


### PR DESCRIPTION
https://github.com/Jxck/jxck.io/blob/b09203a4117db4909a0335d668ecf1ec97fbfc1e/www.jxck.io/assets/css/archive.css#L14-L16

We've added `:` via `::after` pseudo element so we might not want to add it one more after `time` element?

👇  Without this patch:

![image](https://user-images.githubusercontent.com/6782666/62679856-b6b33c00-b9f0-11e9-988b-c7d259d161ad.png)