### PR TITLE
[policies] fix wrong url

### DIFF
--- a/blog.jxck.io/policies/privacy.html
+++ b/blog.jxck.io/policies/privacy.html
@@ -30,7 +30,7 @@
       <li>Google などの第三者配信事業者が Cookie を使用して、ユーザーがそのウェブサイトや他のウェブサイトに過去にアクセスした際の情報に基づいて広告を配信する。
       <li>Google が広告 Cookie を使用することにより、ユーザーがそのサイトや他のサイトにアクセスした際の情報に基づいて、Google やそのパートナーが適切な広告をユーザーに表示している。
       <li>ユーザーは <a href=https://www.google.com/settings/ads>広告設定</a> でパーソナライズ広告を無効にできる
-      <li>または <a href=www.aboutads.info>www.aboutads.info</a> にアクセスすれば、パーソナライズ広告に使われる第三者配信事業者の Cookie を無効にできる。
+      <li>または <a href=https://www.aboutads.info>www.aboutads.info</a> にアクセスすれば、パーソナライズ広告に使われる第三者配信事業者の Cookie を無効にできる。
       <li>詳細については、 <a href=https://policies.google.com/technologies/ads?hl=ja>Google による広告での Cookie の利用方法</a> を参照されたい
     </ul>
   </li>


### PR DESCRIPTION
`www.aboutads.info` is linked to https://blog.jxck.io/policies/www.aboutads.info. I fixed it.