### PR TITLE
Fix typo

### DIFF
--- a/blog.jxck.io/entries/2020-05-22/site-isolation.md
+++ b/blog.jxck.io/entries/2020-05-22/site-isolation.md
@@ -214,7 +214,7 @@ Cross-Origin-Resource-Policy: same-site
 Cross-Origin-Resource-Policy: cross-origin
 ```
 
-same-origin や same-site を指定すれば、ブラウザは secret.json のレスポンスヘッダを見た時点で、メモリへ展開してよいかどうかをブラウザが判断できる。
+same-origin や same-site を指定すれば、ブラウザは secret.js のレスポンスヘッダを見た時点で、メモリへ展開してよいかどうかをブラウザが判断できる。
 
 どんなレスポンスにも使えるため、 CORB で守られないものも守ることができる。
 


### PR DESCRIPTION
The example code for CORP is trying to load a js file so it should be correct to say `.js` below instead of `.json`.