### PR TITLE
Fix wrong path in blog.jxck.io/tags

### DIFF
--- a/.script/template/blog.tags.html.erb
+++ b/.script/template/blog.tags.html.erb
@@ -46,7 +46,7 @@
       <%- entries.reverse.each do |e| -%>
         <li>
           <time datetime=<%= e.created_at %>><%= e.created_at %></time>
-          <a href=<%= e.relative %>><%= e.title %></a>
+          <a href=<%= e.url %>><%= e.title %></a>
           <nav class=tags>
             <ul>
               <%- e.tags.each{|tag| -%>


### PR DESCRIPTION
the links from blog.jxck.io/tags/{tag} to the entry is wrong so 404 error happens. 
I fixed this by using absolute path instead of relative path.

https://blog.jxck.io/tags/web%20font.html