### PR TITLE
fix(mozaic.fm): ep73ゲストのリンクラベルを修正

### DIFF
--- a/mozaic.fm/episodes/73/semantic-web.md
+++ b/mozaic.fm/episodes/73/semantic-web.md
@@ -16,7 +16,7 @@ guest
 
 第 73 回のテーマは Semantic Web です。
 
-今回は [セマンティック・ウェブのためのRDF/OWL入門](https://www.amazon.co.jp/dp/4627829310) や [セマンティック HTML/XHTML](https://www.amazon.co.jp/dp/483993195X) の著者であり、 [ジャパンサーチ](https://jpsearch.go.jp/) などを手掛ける Semantic Web の専門家、 [神崎先生](https://www.kanzaki.com/) 先生をお迎えし
+今回は [セマンティック・ウェブのためのRDF/OWL入門](https://www.amazon.co.jp/dp/4627829310) や [セマンティック HTML/XHTML](https://www.amazon.co.jp/dp/483993195X) の著者であり、 [ジャパンサーチ](https://jpsearch.go.jp/) などを手掛ける Semantic Web の専門家、 [神崎正英](https://www.kanzaki.com/) 先生をお迎えし
 
 Web におけるセマンティクスの歴史や RDF の変遷、ジャパンサーチで行われている作業から見た Semantic Web の現状などについてお聞きしつつ、これからの Web のセマンティクスなどについて議論させていただきました。
 


### PR DESCRIPTION
「神崎先生 先生」となっていたので、お名前をリンクのラベルに。