### PR TITLE
Change to use https instead of http for mozaic.fm

### DIFF
--- a/.script/template/podcast.html.erb
+++ b/.script/template/podcast.html.erb
@@ -6,7 +6,7 @@
 
   <link rel=author    href=https://jxck.io/humans.txt>
   <link rel=manifest  href=/manifest.webmanifest>
-  <link rel=alternate type=application/rss+xml href=http://feed.mozaic.fm title=mozaic.fm>
+  <link rel=alternate type=application/rss+xml href=https://feed.mozaic.fm title=mozaic.fm>
 
   <link rel=canonical href=<%= episode.canonical %>>
   <!--
@@ -60,7 +60,7 @@
       <li><a href=https://itunes.apple.com/jp/podcast/mozaic.fm/id851914495              ><img width=30 height=30 loading=eager src=<%= version("/assets/img/itunes.svg") %>         title=itunes           alt=itunes           ></a>
       <li><a href=https://www.google.com/podcasts?feed=aHR0cHM6Ly9mZWVkLm1vemFpYy5mbS8%3D><img width=30 height=30 loading=eager src=<%= version("/assets/img/google-podcast.svg") %> title="google podcast" alt="google podcast" ></a>
       <li><a href=https://open.spotify.com/show/6dDtbcRlUVKssaNmkuFu5K                   ><img width=30 height=30 loading=eager src=<%= version("/assets/img/spotify.svg") %>        title=spotify          alt=spotify          ></a>
-      <li><a href=http://feed.mozaic.fm                                                  ><img width=30 height=30 loading=eager src=<%= version("/assets/img/podcast.svg") %>        title="rss feed"       alt="rss feed"       ></a>
+      <li><a href=https://feed.mozaic.fm                                                  ><img width=30 height=30 loading=eager src=<%= version("/assets/img/podcast.svg") %>        title="rss feed"       alt="rss feed"       ></a>
       <li id=install class=disabled><button><img width=30 height=30 loading=eager src=<%= version("/assets/img/install.svg") %> title=install alt=install></button>
       <li id=share   class=disabled><button><img width=30 height=30 loading=eager src=<%= version("/assets/img/share.svg") %>   title=share   alt=share  ></button>
       <li id=search><a href=/searches      ><img width=30 height=30 loading=eager src=<%= version("/assets/img/search.svg") %>  title=search  alt=search ></a>

--- a/.script/template/podcast.index.html.erb
+++ b/.script/template/podcast.index.html.erb
@@ -6,7 +6,7 @@
 
   <link rel=author    href=https://jxck.io/humans.txt>
   <link rel=manifest  href=/manifest.webmanifest>
-  <link rel=alternate type=application/rss+xml href=http://feed.mozaic.fm title=mozaic.fm>
+  <link rel=alternate type=application/rss+xml href=https://feed.mozaic.fm title=mozaic.fm>
 
   <link rel=canonical href=https://mozaic.fm>
   <!--
@@ -61,7 +61,7 @@
       <li><a href=https://itunes.apple.com/jp/podcast/mozaic.fm/id851914495              ><img width=30 height=30 loading=eager src=<%= version("/assets/img/itunes.svg") %>         title=itunes           alt=itunes           ></a>
       <li><a href=https://www.google.com/podcasts?feed=aHR0cHM6Ly9mZWVkLm1vemFpYy5mbS8%3D><img width=30 height=30 loading=eager src=<%= version("/assets/img/google-podcast.svg") %> title="google podcast" alt="google podcast" ></a>
       <li><a href=https://open.spotify.com/show/6dDtbcRlUVKssaNmkuFu5K                   ><img width=30 height=30 loading=eager src=<%= version("/assets/img/spotify.svg") %>        title=spotify          alt=spotify          ></a>
-      <li><a href=http://feed.mozaic.fm                                                  ><img width=30 height=30 loading=eager src=<%= version("/assets/img/podcast.svg") %>        title="rss feed"       alt="rss feed"       ></a>
+      <li><a href=https://feed.mozaic.fm                                                  ><img width=30 height=30 loading=eager src=<%= version("/assets/img/podcast.svg") %>        title="rss feed"       alt="rss feed"       ></a>
       <li id=install class=disabled><button><img width=30 height=30 loading=eager src=<%= version("/assets/img/install.svg") %> title=install alt=install></button>
       <li id=share   class=disabled><button><img width=30 height=30 loading=eager src=<%= version("/assets/img/share.svg") %>   title=share   alt=share  ></button>
       <li id=search><a href=/searches      ><img width=30 height=30 loading=eager src=<%= version("/assets/img/search.svg") %>  title=search  alt=search ></a>

--- a/.script/template/podcast.rss2.json.erb
+++ b/.script/template/podcast.rss2.json.erb
@@ -2,7 +2,7 @@
   "rss": {
     "channel": {
       "title": "mozaic.fm",
-      "link": "http://mozaic.fm/",
+      "link": "https://mozaic.fm/",
       "description": "next generation web podcast",
       "generator": "Ruby",
       "language": "ja",
@@ -11,12 +11,12 @@
         "xmlns:atom": "http://www.w3.org/2005/Atom",
         "rel": "self",
         "type": "application/rss+xml",
-        "href": "http://feed.mozaic.fm"
+        "href": "https://feed.mozaic.fm"
       },
       "itunes:author": "Jxck",
       "itunes:category": "Technology",
       "itunes:explicit": "no",
-      "itunes:image": "http://files.mozaic.fm/mozaic.jpeg",
+      "itunes:image": "https://files.mozaic.fm/mozaic.jpeg",
       "itunes:keywords": ["web","technology","programming","it","software","jxck"],
       "itunes:subtitle": "next generation web podcast",
       "itunes:summary": "talking about next generation web technologies hosted by Jxck",
@@ -26,7 +26,7 @@
       "media:description": "next generation web podcast",
       "media:keywords": ["web","technology","programming","it","software","jxck"],
       "media:rating": "nonadult",
-      "media:thumbnail": "http://files.mozaic.fm/mozaic.jpeg",
+      "media:thumbnail": "https://files.mozaic.fm/mozaic.jpeg",
       "itunes:owner": {
         "itunes:email": "block.rxckin.beats@gmail.com",
         "itunes:name": "Jxck"
@@ -36,7 +36,7 @@
           {
             "category": "mozaicfm",
             "enclosure": {
-              "url": "http://<%= episode.audio_file %>",
+              "url": "https://<%= episode.audio_file %>",
               "length": "<%= episode.size %>",
               "type": "audio/mpeg"
             },

--- a/.script/template/podcast.rss2.xml.erb
+++ b/.script/template/podcast.rss2.xml.erb
@@ -2,16 +2,16 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:media="http://search.yahoo.com/mrss/" xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0">
   <channel>
     <title>mozaic.fm</title>
-    <link>http://mozaic.fm/</link>
+    <link>https://mozaic.fm/</link>
     <description>next generation web podcast</description>
     <generator>Ruby</generator>
     <language>ja</language>
     <copyright>Copyright (c) 2014 mozaic.fm. All Rights Reserved. Redistribute, Transcript are not allowed.</copyright>
-    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="self" type="application/rss+xml" href="http://feed.mozaic.fm" />
+    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="self" type="application/rss+xml" href="https://feed.mozaic.fm" />
     <itunes:author>Jxck</itunes:author>
     <itunes:category text="Technology" />
     <itunes:explicit>no</itunes:explicit>
-    <itunes:image href="http://files.mozaic.fm/mozaic.jpeg" />
+    <itunes:image href="https://files.mozaic.fm/mozaic.jpeg" />
     <itunes:keywords>web,technology,programming,it,software,jxck</itunes:keywords>
     <itunes:subtitle>next generation web podcast</itunes:subtitle>
     <itunes:summary>talking about next generation web technologies hosted by Jxck</itunes:summary>
@@ -21,7 +21,7 @@
     <media:description type="plain">next generation web podcast</media:description>
     <media:keywords>web,technology,programming,it,software,jxck</media:keywords>
     <media:rating>nonadult</media:rating>
-    <media:thumbnail url="http://files.mozaic.fm/mozaic.jpeg" />
+    <media:thumbnail url="https://files.mozaic.fm/mozaic.jpeg" />
     <itunes:owner>
       <itunes:email>block.rxckin.beats@gmail.com</itunes:email>
       <itunes:name>Jxck</itunes:name>
@@ -29,7 +29,7 @@
 <% episodes.each do |episode| %>
     <item>
       <category>mozaicfm</category>
-      <enclosure url="http://<%= episode.audio_file %>" length="<%= episode.size %>" type="audio/mpeg" />
+      <enclosure url="https://<%= episode.audio_file %>" length="<%= episode.size %>" type="audio/mpeg" />
       <guid isPermaLink="false"><%= episode.canonical %></guid>
       <link><%= episode.canonical %></link>
       <pubDate><%= episode.pubDate %></pubDate>

--- a/.script/template/podcast.search.html.erb
+++ b/.script/template/podcast.search.html.erb
@@ -6,7 +6,7 @@
 
   <link rel=author    href=https://jxck.io/humans.txt>
   <link rel=manifest  href=/manifest.webmanifest>
-  <link rel=alternate type=application/rss+xml href=http://feed.mozaic.fm title=mozaic.fm>
+  <link rel=alternate type=application/rss+xml href=https://feed.mozaic.fm title=mozaic.fm>
 
   <link rel=canonical href=https://mozaic.fm>
 
@@ -27,7 +27,7 @@
       <li><a href=https://itunes.apple.com/jp/podcast/mozaic.fm/id851914495              ><img width=30 height=30 loading=eager src=/assets/img/itunes.svg         title=itunes           alt=itunes           ></a>
       <li><a href=https://www.google.com/podcasts?feed=aHR0cHM6Ly9mZWVkLm1vemFpYy5mbS8%3D><img width=30 height=30 loading=eager src=/assets/img/google-podcast.svg title="google podcast" alt="google podcast" ></a>
       <li><a href=https://open.spotify.com/show/6dDtbcRlUVKssaNmkuFu5K                   ><img width=30 height=30 loading=eager src=/assets/img/spotify.svg        title=spotify          alt=spotify          ></a>
-      <li><a href=http://feed.mozaic.fm                                                  ><img width=30 height=30 loading=eager src=/assets/img/podcast.svg        title="rss feed"       alt="rss feed"       ></a>
+      <li><a href=https://feed.mozaic.fm                                                  ><img width=30 height=30 loading=eager src=/assets/img/podcast.svg        title="rss feed"       alt="rss feed"       ></a>
       <li id=install class=disabled><a><img width=30 height=30 loading=eager src=/assets/img/install.svg  title=install alt=install></a>
       <li id=share   class=disabled><a><img width=30 height=30 loading=eager src=/assets/img/share.svg    title=share   alt=share  ></a>
       <li id=search><a href=/searches ><img width=30 height=30 loading=eager src=/assets/img/search.svg   title=search  alt=search ></a>


### PR DESCRIPTION
Thank you for your very useful and wonderful articles and podcasts.
I love listening to Monthly Web podcasts.

Unfortunately, I cannot play mozaic.fm on [Google Podcasts on the Web](https://podcasts.google.com/) because mozaic.fm uses http for link to the audio file (mp3) on RSS feed. I can play it normally on the mobile app.
I think that it should use https for link to the audio data (mp3) of the enclosure tag to solve this problem.
This pull request change to use https instead of http for mozaic.fm.
![image](https://user-images.githubusercontent.com/28337009/126743345-a553daf1-c9f8-4e32-bef6-07f8b2dcd5a8.png)