### PR TITLE
Fix markdown.css for list

### DIFF
--- a/www.jxck.io/assets/css/markdown.css
+++ b/www.jxck.io/assets/css/markdown.css
@@ -57,14 +57,14 @@ strong {
 }
 
 ul {
-  li::before {
+  > li::before {
     content: "- " / "";
   }
 }
 
 ol {
   counter-reset: list;
-  li::before {
+  > li::before {
     counter-increment: list;
     content: counter(list) ". ";
   }


### PR DESCRIPTION
Fixed a bug where a `<ul>` inside an `<ol>` was incorrectly counting up.

| before | after |
|:------:|:-----:|
| <img width="372" height="236" alt="スクリーンショット 2026-02-11 20 18 00" src="https://github.com/user-attachments/assets/9aa51f8e-0285-4d29-9cee-5730cc553ad0" /> | <img width="366" height="238" alt="スクリーンショット 2026-02-11 20 18 35" src="https://github.com/user-attachments/assets/29fbcdbf-1470-4c53-8ff1-201d827d715a" /> |

https://blog.jxck.io/entries/2026-01-04/donation-for-web.html